### PR TITLE
Remove rake as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'commander-openflighthpc'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'hashie'
-gem 'rake'
 gem 'tty-table'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,6 @@ GEM
     pry-byebug (3.8.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    rake (13.0.1)
     strings (0.1.7)
       strings-ansi (~> 0.1)
       unicode-display_width (~> 1.5)
@@ -68,7 +67,6 @@ DEPENDENCIES
   hashie
   pry
   pry-byebug
-  rake
   tty-table
 
 BUNDLED WITH


### PR DESCRIPTION
This can cause issues when using a different version than specified
the Gemfile.lock

Instead rake is installed along side ruby, so as long as the GEM_HOME
and GEM_PATH are sane, it should work