### PR TITLE
Remember to bump the version number

### DIFF
--- a/lib/charge_client/cli.rb
+++ b/lib/charge_client/cli.rb
@@ -32,7 +32,7 @@ require 'faraday'
 require 'faraday_middleware'
 
 module ChargeClient
-  VERSION = '0.1.1'
+  VERSION = '0.1.4'
 
   class BaseError < StandardError; end
   class ServerError < BaseError; end


### PR DESCRIPTION
The 0.1.2  and 0.1.3 tags have been marked as pre-releases as this was
not done